### PR TITLE
Improve micro typography

### DIFF
--- a/Aufnahmeantrag_aktiv.tex
+++ b/Aufnahmeantrag_aktiv.tex
@@ -8,6 +8,7 @@
 \usepackage{eurosym}
 \usepackage[shortlabels]{enumitem}
 \usepackage{csquotes}
+\usepackage[babel=true]{microtype}
 
 % ToDo-Notes: Parameter "disable" versteckt alle Notizen.
 \usepackage[colorinlistoftodos]{todonotes}
@@ -26,13 +27,14 @@
 \usepackage{tabularx}
 \usepackage{xcolor}
 
+\include{n39common}
 \include{headfoot}
 
 \begin{document}
-\section*{Aufnahmeantrag\\ zur aktiven Mitgliedschaft im Netz39\ e.V.}
+\section*{Aufnahmeantrag\\ zur aktiven Mitgliedschaft im \netzEV}
 
 \begin{Form}
-Hiermit beantrage ich die aktive Mitgliedschaft als natürliche Person im Netz39 e.V.
+Hiermit beantrage ich die aktive Mitgliedschaft als natürliche Person im \netzEV
 
 \begin{center}
 \begin{tabularx}{\textwidth}{@{}p{5cm} X}
@@ -62,7 +64,7 @@ E-Mail-Adresse & \dotfill%
 \end{tabularx}
 \end{center}
 
-Die Mitgliedsbeiträge richten sich nach der jeweils gültigen Beschlussfassung der Mitgliederversammlung. Mit meiner Unterschrift erkenne ich die Satzung des Netz39\ e.V. an und verpflichte mich, die satzungsgemäßen Ziele des Netz39\ e.V. nach Kräften zu unterstützen.
+Die Mitgliedsbeiträge richten sich nach der jeweils gültigen Beschlussfassung der Mitgliederversammlung. Mit meiner Unterschrift erkenne ich die Satzung des \netzEV an und verpflichte mich, die satzungsgemäßen Ziele des \netzEV nach Kräften zu unterstützen.
 
 \vspace{2cm}
 \begin{tabular}{p{7cm}p{.5cm}p{7cm}}

--- a/Aufnahmeantrag_foerder_jur.tex
+++ b/Aufnahmeantrag_foerder_jur.tex
@@ -8,6 +8,7 @@
 \usepackage{eurosym}
 \usepackage[shortlabels]{enumitem}
 \usepackage{csquotes}
+\usepackage[babel=true]{microtype}
 
 % ToDo-Notes: Parameter "disable" versteckt alle Notizen.
 \usepackage[colorinlistoftodos]{todonotes}
@@ -26,13 +27,14 @@
 \usepackage{tabularx}
 \usepackage{xcolor}
 
+\include{n39common}
 \include{headfoot}
 
 \begin{document}
-\section*{Aufnahmeantrag\\ für juristische Personen zur Fördermitgliedschaft im Netz39\ e.V.}
+\section*{Aufnahmeantrag\\ für juristische Personen zur Fördermitgliedschaft im \netzEV}
 
 \begin{Form}
-Hiermit beantrage ich die Fördermitgliedschaft als juristische Person im Netz39\ e.V.
+Hiermit beantrage ich die Fördermitgliedschaft als juristische Person im \netzEV
 
 \begin{center}
 \begin{tabularx}{\textwidth}{@{}p{5cm} X}
@@ -58,7 +60,7 @@ Vereinbarte Förderung & \dotfill%
 \end{tabularx}
 \end{center}
 
-Die Mitgliedsbeiträge richten sich nach der jeweils gültigen Beschlussfassung der Mitgliederversammlung. Mit meiner Unterschrift erkenne ich die Satzung des Netz39\ e.V. an und verpflichte mich, die satzungsgemäßen Ziele des Netz39\ e.V. nach Kräften zu unterstützen.
+Die Mitgliedsbeiträge richten sich nach der jeweils gültigen Beschlussfassung der Mitgliederversammlung. Mit meiner Unterschrift erkenne ich die Satzung des \netzEV an und verpflichte mich, die satzungsgemäßen Ziele des \netzEV nach Kräften zu unterstützen.
 
 \vspace{2cm}
 \begin{tabular}{p{7cm}p{.5cm}p{7cm}}

--- a/Aufnahmeantrag_foerder_nat.tex
+++ b/Aufnahmeantrag_foerder_nat.tex
@@ -8,6 +8,7 @@
 \usepackage{eurosym}
 \usepackage[shortlabels]{enumitem}
 \usepackage{csquotes}
+\usepackage[babel=true]{microtype}
 
 % ToDo-Notes: Parameter "disable" versteckt alle Notizen.
 \usepackage[colorinlistoftodos]{todonotes}
@@ -26,13 +27,14 @@
 \usepackage{tabularx}
 \usepackage{xcolor}
 
+\include{n39common}
 \include{headfoot}
 
 \begin{document}
-\section*{Aufnahmeantrag\\ für natürliche Personen zur Fördermitgliedschaft im Netz39\ e.V.}
+\section*{Aufnahmeantrag\\ für natürliche Personen zur Fördermitgliedschaft im \netzEV}
 
 \begin{Form}
-Hiermit beantrage ich die Fördermitgliedschaft als natürliche Person im Netz39\ e.V.
+Hiermit beantrage ich die Fördermitgliedschaft als natürliche Person im \netzEV
 
 \begin{center}
 \begin{tabularx}{\textwidth}{@{}p{5cm} X}
@@ -65,9 +67,9 @@ E-Mail-Adresse & \dotfill%
 \cb{cb_30} Ich möchte 30 \euro{} / Monat zahlen\\
 \cb{cb_beitrag} Ich möchte \tf{beitrag}{1cm} \euro{} / Monat zahlen\\
 
-Ein Wechsel aus der Fördermitgliedschaft in die aktive Mitgliedschaft ist jederzeit möglich. Für den umgekehrten Wechsel gelten die in der Satzung festgelegten regulären Kündigungsfristen der aktiven Mitgliedschaft. 
+Ein Wechsel aus der Fördermitgliedschaft in die aktive Mitgliedschaft ist jederzeit möglich. Für den umgekehrten Wechsel gelten die in der Satzung festgelegten regulären Kündigungsfristen der aktiven Mitgliedschaft.
 
-Mit meiner Unterschrift erkenne ich die Satzung des Netz39\ e.V. an und verpflichte mich, die satzungsgemäßen Ziele des Netz39\ e.V. nach Kräften zu unterstützen.
+Mit meiner Unterschrift erkenne ich die Satzung des \netzEV an und verpflichte mich, die satzungsgemäßen Ziele des \netzEV nach Kräften zu unterstützen.
 
 \vspace{1cm}
 \begin{tabular}{p{7cm}p{.5cm}p{7cm}}

--- a/Einzug.tex
+++ b/Einzug.tex
@@ -8,6 +8,7 @@
 \usepackage{eurosym}
 \usepackage[shortlabels]{enumitem}
 \usepackage{csquotes}
+\usepackage[babel=true]{microtype}
 
 % ToDo-Notes: Parameter "disable" versteckt alle Notizen.
 \usepackage[colorinlistoftodos]{todonotes}
@@ -26,13 +27,14 @@
 \usepackage{tabularx}
 \usepackage{xcolor}
 
+\include{n39common}
 \include{headfoot}
 
 \begin{document}
 \begin{minipage}{\textwidth}
 Gläubiger-Identifikationsnummer: DE02ZZZ00000139516
 
-Mandatsreferenznumer: Wird separat vom Netz39\ e.V. mitgeteilt.
+Mandatsreferenznumer: Wird separat vom \netzEV mitgeteilt.
 \end{minipage}
 \section*{V E R T R A G}
 
@@ -49,12 +51,12 @@ Vorname        & \dotfill \\
 
 \section*{Einzugsermächtigung}
 \begin{minipage}{\textwidth}
-Ich ermächtige Netz39\ e.V. widerruflich, die von mir zu entrichtenden Zahlungen bei Fälligkeit durch Lastschrift von meinem Konto einzuziehen.
+Ich ermächtige \netzEV widerruflich, die von mir zu entrichtenden Zahlungen bei Fälligkeit durch Lastschrift von meinem Konto einzuziehen.
 \end{minipage}
 
 \section*{SEPA-Lastschriftmandat}
 \begin{minipage}{\textwidth}
-Ich ermächtige Netz39\ e.V., Zahlungen von meinem Konto mittels Lastschrift einzuziehen. Zugleich weise ich mein Kreditinstitut an, die von Netz39\ e.V. auf mein Konto gezogenen Lastschriften einzulösen.
+Ich ermächtige \netzEV Zahlungen von meinem Konto mittels Lastschrift einzuziehen. Zugleich weise ich mein Kreditinstitut an, die von \netzEV auf mein Konto gezogenen Lastschriften einzulösen.
 
 Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen. Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen.
 \end{minipage}
@@ -71,7 +73,7 @@ BIC            & \dotfill
 \end{tabularx}
 
 \begin{minipage}{\textwidth}
-Vor dem ersten Einzug einer SEPA-Basislastschrift wird mich Netz39\ e.V. über den Einzug in dieser Verfahrensart unterrichten.
+Vor dem ersten Einzug einer SEPA-Basislastschrift wird mich \netzEV über den Einzug in dieser Verfahrensart unterrichten.
 \end{minipage}
 
 \vspace{2cm}

--- a/headfoot.tex
+++ b/headfoot.tex
@@ -74,7 +74,7 @@
 \unitlength1mm
 \begin{picture}(0,0)
       \put(0, 7){\parbox{180mm}{\n39logo}}
-      \put(17,6){\parbox{180mm}{ \sffamily \huge Netz39 e.V.}}
+      \put(17,6){\parbox{180mm}{ \sffamily \huge \netzEV}}
 \end{picture}
 }
 \setlength{\footheight}{10em}

--- a/n39common.tex
+++ b/n39common.tex
@@ -1,0 +1,2 @@
+% Leerraum ein achtel Geviert, Kerning angepasst
+\newcommand{\netzEV}{Netz39~e.\hspace{0.12em}V\hspace{-0.1em}. }


### PR DESCRIPTION
- import package 'microtype'
- introduce macro for "Netz39"
- replace all occurences of "Netz39 e.V." with new macro
- adapt horizontal whitespace and kerning for new macro \netzEV

The German recommendations for abbreviations recommend setting a thin
space in between parts of an abbreviation. See for example:

- http://faql.de/typographie.html#abk
- https://de.wikipedia.org/wiki/Schmales_Leerzeichen

With the font used (lmodern) the '\,' or 1/6 em wide whitespace is a good
start, but visually still a little wide, so a space slightly less than
an "Achtelgeviert" is used.

Additionally the kerning between the 'V' and the following dot was
improved. That dot stood out far too much to the right. Current state is
result of comparision with typographically well looking examples
I got from a professional typo expert on another channel.