### PR TITLE
Markiere BIC als optional

### DIFF
--- a/Einzug.tex
+++ b/Einzug.tex
@@ -70,7 +70,7 @@ Kontoinhaber   & \dotfill \\
 IBAN           & \dotfill\\
 
                & \tf{bic}{10cm}\\
-BIC            & \dotfill
+BIC\footnote{Für Konten innerhalb Deutschlands ist die BIC optional.}            & \dotfill
 \end{tabularx}
 
 \begin{minipage}{\textwidth}


### PR DESCRIPTION
Dieser PR ergänzt das BIC-Feld um eine Fußnote und markiert es damit als optional für Konten innerhalb Deutschlands.