### PR TITLE
Ergänze SEPA-Mandat um Zwecke

### DIFF
--- a/Einzug.tex
+++ b/Einzug.tex
@@ -58,7 +58,16 @@ Ich ermächtige \netzEV widerruflich, die von mir zu entrichtenden Zahlungen bei
 \section*{SEPA-Lastschriftmandat}
 \begin{minipage}{\textwidth}
 Ich ermächtige \netzEV Zahlungen von meinem Konto mittels Lastschrift einzuziehen. Zugleich weise ich mein Kreditinstitut an, die von \netzEV auf mein Konto gezogenen Lastschriften einzulösen.
+Das Mandat deckt die folgenden Zwecke ab:
+\begin{itemize}[noitemsep]
+ \item Verbindlichkeiten gemäß der Finanzordnung, z.B. Mitgliedsbeiträge
+ \item Zugesagte regelmäßige Spenden
+ \item Interne Crowd-Fundings
+\end{itemize}
+\end{minipage}
 
+\begin{minipage}{\textwidth}
+\small
 Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen. Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen.
 \end{minipage}
 
@@ -77,7 +86,7 @@ BIC            & \dotfill
 Vor dem ersten Einzug einer SEPA-Basislastschrift wird mich \netzEV über den Einzug in dieser Verfahrensart unterrichten.
 \end{minipage}
 
-\vspace{2cm}
+\vspace{1cm}
 \begin{tabular}{p{7cm}p{.5cm}p{7cm}}
 \tf{datum}{7cm} & & \\
 \dotfill & & \dotfill \\


### PR DESCRIPTION
Auf der MV am 2025-07-02 haben wir beschlossen, das SEPA-Mandat um Interne Crowd-Fundings zu erweitern. Dieser Zweck wird mit diesem PR aufgenommen. Außerdem werden die bisher gelebten Zwecke (Mitgliedsbeiträge, Spenden) explizit erwähnt.

[Antrag_Ergaenzung_des_SEPA-Mandats_fuer_Crowd_Fundings.pdf](https://github.com/user-attachments/files/21055278/Antrag_Ergaenzung_des_SEPA-Mandats_fuer_Crowd_Fundings.pdf)
