### PR TITLE
(Re)Name checkboxes and text fields

### DIFF
--- a/Aufnahmeantrag_aktiv.tex
+++ b/Aufnahmeantrag_aktiv.tex
@@ -74,14 +74,14 @@ E-Mail-Adresse & \dotfill%
 \textbf{Beitrag:} \\[0.4cm]
 \CheckBox[name=checkBeitragVoll,width=0.4cm, height=0.3cm, bordercolor=black, backgroundcolor=white]{} Voll(30€) \hspace{1cm} \CheckBox[name=checkBeitragErm,width=0.4cm, height=0.3cm ,bordercolor=black, backgroundcolor=white]{} 
 Ermäßigt:  \TextField[
-  name=betrag,
+  name=textBeitragErm,
   width=3cm,
   height=0.4cm,
   bordercolor=black,
   backgroundcolor=white
 ]{\makebox[3cm][l]{\dotfill}} € / Monat \\[0.3cm]
 zusätzliche monatliche Spende:    \hspace{0.15cm} \TextField[
-  name=betrag,
+  name=textBeitragSpende,
   width=3cm,
   height=0.4cm,
   bordercolor=black,

--- a/Aufnahmeantrag_aktiv.tex
+++ b/Aufnahmeantrag_aktiv.tex
@@ -72,7 +72,7 @@ E-Mail-Adresse & \dotfill%
 
 \noindent
 \textbf{Beitrag:} \\[0.4cm]
-\CheckBox[width=0.4cm, height=0.3cm, bordercolor=black, backgroundcolor=white]{} Voll(30€) \hspace{1cm} \CheckBox[width=0.4cm, height=0.3cm ,bordercolor=black, backgroundcolor=white]{} 
+\CheckBox[name=checkBeitragVoll,width=0.4cm, height=0.3cm, bordercolor=black, backgroundcolor=white]{} Voll(30€) \hspace{1cm} \CheckBox[name=checkBeitragErm,width=0.4cm, height=0.3cm ,bordercolor=black, backgroundcolor=white]{} 
 Ermäßigt:  \TextField[
   name=betrag,
   width=3cm,


### PR DESCRIPTION
The checkboxes for membership fees were not named and were therefore both activated when the user tried to activate one of them.
The text fields for reduced membership fees and donations had the same name, so that when a reduced fee or donation was entered, both fields were filled in.