### PR TITLE
Add git info as PDF revision in footnote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     - name: Fetch tags
       run: git fetch --prune --unshallow --tags
 
-    - name: get Git commit info
+    - name: get Git tag info
       run: |
-        echo "\\def\\gitHash{`git rev-parse --short HEAD`}" > gitinfo.tex
-        echo "\\def\\gitTag{`git describe --tags --abbrev=0 || echo 'no-tag'`}" >> gitinfo.tex
+        echo "\\def\\gitTag{`git describe --tags || echo 'no-tag'`}" >> gitinfo.tex
 
     - name: Build PDFs.
       uses: xu-cheng/latex-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,13 @@ jobs:
     - name: Checkout code.
       uses: actions/checkout@v4
       
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+
     - name: get Git commit info
       run: |
         echo "\\def\\gitHash{`git rev-parse --short HEAD`}" > gitinfo.tex
+        echo "\\def\\gitTag{`git describe --tags --abbrev=0 || echo 'no-tag'`}" >> gitinfo.tex
 
     - name: Build PDFs.
       uses: xu-cheng/latex-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: CI
+name: Compile LaTeX files to PDF
 on:
   push:
     branches:
@@ -13,6 +13,11 @@ jobs:
     steps:
     - name: Checkout code.
       uses: actions/checkout@v4
+      
+    - name: get Git commit info
+      run: |
+        echo "\\def\\gitHash{`git rev-parse --short HEAD`}" > gitinfo.tex
+
     - name: Build PDFs.
       uses: xu-cheng/latex-action@v3
       with:
@@ -21,6 +26,7 @@ jobs:
           Aufnahmeantrag_aktiv.tex
           Aufnahmeantrag_foerder_nat.tex
           Aufnahmeantrag_foerder_jur.tex
+
     - name: Upload PDFs.
       uses: actions/upload-artifact@v4
       with:

--- a/headfoot.tex
+++ b/headfoot.tex
@@ -64,6 +64,7 @@
 	  %% Logo End
 }
 % will be overriden by GitHub action at building PDFs
+\def\gitTag{vX.X.X} 
 \def\gitHash{xxxxxxx}
 \InputIfFileExists{gitinfo.tex}{}{}
 
@@ -101,5 +102,5 @@
     \ %
 \end{tabular}% 
 \vfill
-\hfill \scriptsize PDF-Revision: git-\gitHash
+\hfill \scriptsize PDF-Revision: \gitTag (git-\gitHash)
 }

--- a/headfoot.tex
+++ b/headfoot.tex
@@ -64,8 +64,7 @@
 	  %% Logo End
 }
 % will be overriden by GitHub action at building PDFs
-\def\gitTag{vX.X.X} 
-\def\gitHash{xxxxxxx}
+\def\gitTag{vX.X.X}
 \InputIfFileExists{gitinfo.tex}{}{}
 
 \usepackage[headsepline]{scrlayer-scrpage}
@@ -102,5 +101,5 @@
     \ %
 \end{tabular}% 
 \vfill
-\hfill \scriptsize PDF-Revision: \gitTag (git-\gitHash)
+\hfill \scriptsize PDF-Revision: \gitTag
 }

--- a/headfoot.tex
+++ b/headfoot.tex
@@ -63,6 +63,9 @@
 	  \end{tikzpicture}
 	  %% Logo End
 }
+% will be overriden by GitHub action at building PDFs
+\def\gitHash{xxxxxxx}
+\InputIfFileExists{gitinfo.tex}{}{}
 
 \usepackage[headsepline]{scrlayer-scrpage}
 \renewcommand{\headfont}{\sffamily}
@@ -96,5 +99,7 @@
     Amtsgericht Stendal\\
     VR\ 3169\\
     \ %
-\end{tabular}%
+\end{tabular}% 
+\vfill
+\hfill \scriptsize PDF-Revision: git-\gitHash
 }


### PR DESCRIPTION
Mit dem PR  wird beim Builden der PDFs (von Github Action)  die jeweiligen git tags und commit hash in die Fußzeile gesetzt, sodass man nachvollziehen kann, dass stets die aktuelle Version genutzt wird.

So sieht es dann aus:

<img width="1889" height="249" alt="image" src="https://github.com/user-attachments/assets/623c2cd9-78f6-4f5d-bfeb-2109abb87aca" />

Es wurde hier erfolgreich getestet: https://github.com/MG-5/gitinfo-in-footnote