### PR TITLE
Fix release action to use build process from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Compile LaTeX files to PDF
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches: []
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Make Release
+name: Create Release
 
 on:
   push:
@@ -9,18 +9,18 @@ on:
 
 jobs:
   build:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    uses: Netz39/Mitgliedsantraege/.github/workflows/ci.yml@main
+    
+  create-release:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code.
-        uses: actions/checkout@v4
-      - name: Build PDFs.
-        uses: xu-cheng/latex-action@v3
+      - name: Retrieve pdf files
+        uses: actions/download-artifact@v4.1.7
         with:
-          root_file: |
-            Einzug.tex
-            Aufnahmeantrag_aktiv.tex
-            Aufnahmeantrag_foerder_nat.tex
-            Aufnahmeantrag_foerder_jur.tex
+          name: PDFs
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
 Ich habe von [Netz39/Ordnungen](https://github.com/netz39/Ordnungen/blob/main/.github/workflows/release.yml) abgeguckt. Dort greift Release auf Build (definiert in CI.yml)  zu. 
 
 